### PR TITLE
Rename workflow to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Storybook
+name: CI
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  storybook:
+  pipeline:
     runs-on: ubuntu-latest
     steps:
       - uses: Taucher2003/GitLab-Pipeline-Action@1.2.0
@@ -30,7 +30,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: <!-- glpa_comment:storybook -->
+          body-includes: <!-- glpa_comment:pipeline -->
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v3
@@ -39,6 +39,6 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            <!-- glpa_comment:storybook -->
+            <!-- glpa_comment:pipeline -->
             ${{ steps.pipeline.outputs.SUMMARY_TEXT }}
           edit-mode: replace


### PR DESCRIPTION
The pipeline will not only contain storybook jobs in the future. Lets make the workflow more inclusive for possible new jobs like linting or testing.